### PR TITLE
Issue 97 - Add prev and next buttons at the bottom of chapter pages

### DIFF
--- a/nuxt.config.js
+++ b/nuxt.config.js
@@ -23,6 +23,15 @@ module.exports = {
   */
   loading: { color: '#383838' },
   /*
+  ** Customize routing behavior
+  */
+  router: {
+    // always scroll back to top when navigating
+    scrollBehavior: function(to, from, savedPosition) {
+      return { x: 0, y: 0 };
+    }
+  },
+  /*
   ** Build configuration
   */
   build: {

--- a/pages/learning-paths/_id.vue
+++ b/pages/learning-paths/_id.vue
@@ -14,7 +14,7 @@
             aria-label="pagination">
             <a
               :disabled="chapterIndex === 0"
-              class="pagination-previous is-marginless chapter-nav-previous"
+              class="pagination-previous is-marginless is-hidden-tablet chapter-nav-previous"
               @click="prevChapter(chapterIndex)">
               <span class="icon">
                 <i class="fas fa-angle-left"/>
@@ -47,13 +47,12 @@
             </ul>
             <a
               :disabled="chapterIndex > chapters.length -2"
-              class="pagination-next is-marginless chapter-nav-next"
+              class="pagination-next is-marginless is-hidden-tablet chapter-nav-next"
               @click="nextChapter(chapterIndex)">
               <span class="icon">
                 <i class="fas fa-angle-right"/>
               </span>
             </a>
-
           </nav>
         </div>
       </div>
@@ -61,7 +60,45 @@
         <h3 class="title is-5 mb-2 has-text-weight-bold mt-3">
           Chapter {{ chapterIndex + 1 }} of {{ chapters.length }}:
         </h3>
-        <nuxt-child />
+        <nuxt-child :key="$route.path" />
+        <div class="chapter-nav-background mt-5">
+          <div class="pt-0 pb-0">
+            <nav class="pagination is-centered is-large">
+              <a
+                :disabled="chapterIndex === 0"
+                class="pagination-previous is-marginless chapter-nav-previous chapter-prev-next-box"
+                @click="prevChapter(chapterIndex)">
+                <span class="icon">
+                  <i class="fas fa-angle-left"/>
+                </span>
+              </a>
+              <div class="pagination-list chapter-prev-next">
+                <div
+                  :class="{ 'is-disabled': chapterIndex === 0 }"
+                  class="chapter-prev-next-box pagination-link is-marginless">
+                  <span class="is-size-5 has-text-weight-bold">
+                    Previous <span class="is-hidden-mobile">Chapter</span>
+                  </span>
+                </div>
+                <div
+                  :class="{ 'is-disabled': chapterIndex > chapters.length -2 }"
+                  class="chapter-prev-next-box pagination-link is-marginless">
+                  <span class="is-size-5 has-text-weight-bold">
+                    Next <span class="is-hidden-mobile">Chapter</span>
+                  </span>
+                </div>
+              </div>
+              <a
+                :disabled="chapterIndex > chapters.length -2"
+                class="pagination-next is-marginless chapter-nav-next chapter-prev-next-box"
+                @click="nextChapter(chapterIndex)">
+                <span class="icon">
+                  <i class="fas fa-angle-right"/>
+                </span>
+              </a>
+            </nav>
+          </div>
+        </div>
       </div>
     </div>
     <div
@@ -193,13 +230,27 @@ export default {
 .chapter-nav-info {
   display: none;
 }
+.chapter-prev-next {
+  justify-content: space-between !important;
+  flex-grow: 1 !important;
+}
+.chapter-prev-next-box {
+  border-radius: 0;
+  border-color: white;
+  color: white;
+  background: $emf;
+  &.is-disabled {
+    opacity: 0.5;
+  }
+}
+a.chapter-prev-next-box {
+  &:hover {
+    background: $primary;
+  }
+}
 @include tablet() {
   .main-text {
     width: 80%;
-  }
-  .pagination-previous,
-  .pagination-next {
-    display: none;
   }
   .chapter-nav-link {
     display: block;


### PR DESCRIPTION
Some notes:
- Mobile still needs to be styled (but is functional). This should happen when we bring mobile in line with mockups. 
- I've added a global config setting to make the page jump back to the top when navigating. This is necessary for the prev/next buttons at the bottom of the page, but if this turns out to result in less good ux on other navigation actions, I can look into a local solution
- This PR should also solve #120 !