### PR TITLE
Issue 100 - Add some styling tweaks on homepage and about

### DIFF
--- a/components/UI/buttons/TextCircleButton.vue
+++ b/components/UI/buttons/TextCircleButton.vue
@@ -49,7 +49,10 @@ export default {
 .circle {
   transition: $smf-transition;
   background: $emf;
-  @include circle(30px);
+  @include circle(20px);
+  @include tablet() {
+    @include circle(30px);
+  }
 }
 .circle-button {
   &:hover {

--- a/components/ab_testing/HomePage.vue
+++ b/components/ab_testing/HomePage.vue
@@ -73,12 +73,11 @@ export default {
 .home-body {
   height: 100%;
 }
-// .columns {
-//   margin: 0;
-// }
 .column {
   background-size: cover;
-  // padding: 0;
+}
+.home-box {
+  margin-bottom: 1rem;
 }
 .left-col,
 .right-col {
@@ -89,13 +88,13 @@ export default {
     font-weight: 900;
   }
   .overlay {
-    padding-top: 4rem !important;
     transition: $smf-transition;
   }
 }
 .left-col {
   .overlay {
     background-color: rgba($emf, 0.8);
+    padding-top: 4rem !important;
     &:hover {
       background-color: rgba($emf, 0.95);
     }
@@ -141,7 +140,7 @@ export default {
     }
   }
   .home-box {
-    padding-bottom: 2rem;
+    margin-bottom: 2rem;
   }
   .circle {
     $circle-radius: 60px;

--- a/pages/about/index.vue
+++ b/pages/about/index.vue
@@ -7,7 +7,7 @@
       />
     </section>
     <section class="section">
-      <div class="container">
+      <div class="container is-fluid smf-container">
         <div class="columns">
           <div class="column wrap text-left is-half">
             <h3 class="title is-4">The Ellen MacArthur Foundation</h3>
@@ -25,7 +25,7 @@
             class="column is-paddingless is-half">
             <div class="triangle-left"/>
           </div>
-          <div class="column wrap text-right has-text-right is-half">
+          <div class="column wrap text-right has-text-right-tablet is-half">
             <h3 class="title is-4">Circular Economy Learning</h3>
             <p>We at the Ellen MacArthur Foundation are currently developing an <a href="https://www.ellenmacarthurfoundation.org/programmes/education/schmidt-macarthur-fellowship/application">exciting new initiative</a> to take circular economy learning to a wide audience, using our knowledge base and expertise to provide global reach. This tool has been designed as a prototype of our online learning platform and provides you, the learner, with the option to follow a curated path through the learning material or to browse the content freely.</p>
           </div>
@@ -63,6 +63,9 @@ export default {
 </script>
 
 <style lang="scss" scoped>
+.smf-container {
+  margin: 0;
+}
 .columns {
   .column {
     &.text-left {

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -14,13 +14,11 @@
 </template>
 
 <script>
-import TextCircleButton from "~/components/UI/buttons/TextCircleButton";
 import HomePage from "~/components/ab_testing/HomePage";
 
 export default {
   components: {
-    HomePage,
-    TextCircleButton
+    HomePage
   },
   data: function() {
     return {


### PR DESCRIPTION
Includes:
- Mobile homepage more in line with hi-fi designs
- About page: left align all text on mobile
- About page: fix container issue on tablet and above
- Made call to action circles smaller across the app on mobile (more in line with mockups)